### PR TITLE
Localhackday API wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,7 @@
   <!--  Scripts-->
   <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
   <script src="js/materialize.js"></script>
+  <script src="js/localhackday.js"></script>
   <script src="js/init.js"></script>
 
 </body>

--- a/js/localhackday.js
+++ b/js/localhackday.js
@@ -1,17 +1,109 @@
 (function($){
 
+  /**
+   * The LocalhackDayEvent (which allows you to manipulate results from Localhackday.getAllEvents)
+   */
+  var LocalhackdayEvent;
+  LocalhackdayEvent = function(data) { this.raw = data; };
+  LocalhackdayEvent.prototype = Object;
+  LocalhackdayEvent.prototype.id = function() { return this.raw.id; }
+  LocalhackdayEvent.prototype.city = function() { return this.raw.city; }
+  LocalhackdayEvent.prototype.location = function() { return this.raw.geo.address; }
+  LocalhackdayEvent.prototype.ll = function() { return [this.raw.geo.lat, this.raw.geo.lng]; }
+  LocalhackdayEvent.prototype.organizerImage = function() { return this.raw.organizers.image; }
+  LocalhackdayEvent.prototype.organizerName = function() { return this.raw.organizers.name; }
+  LocalhackdayEvent.prototype.organizerOrganization = function() { return this.raw.organizers.organization; }
+  LocalhackdayEvent.prototype.organizerUrl = function() { return this.raw.organizers.url; }
+  LocalhackdayEvent.prototype.toString = function() { return this.raw; };
+
+  LocalhackdayEvent.prototype.registerHacker = function(first_name, last_name, email, school, year, major, callbackSuccess, callbackError) {
+    Localhackday.registerNewHackerForEvent(this.id(), first_name, last_name, email, school, year, major, callbackSuccess, callbackError);
+  };
+
+  /**
+   * The main Localhackday class.
+   */
+
   var Localhackday = {
     base_url: "http://organizer.mlh.io.dev/localhackday/api", // Base API URL
 
     // START View all events from the API
-    getAll: function(callback) {
+    /**
+     * Example code:
+     * Localhackday.getAllEvents(function(events){
+     *   console.log(events);
+     *   // events[0].registerHacker("Steven", "Smith", "stevensmith@example.com", "Steven High School", "2015", "History", function(){ console.log("Registered Steven Smith!"); })
+     * });
+     */
+    getAllEvents: function(callback) {
       this.queryAPI("GET", "/events.json", null, function(response) {
-        console.log(response);
+        var events = response.events.map(function(ev){ return new LocalhackdayEvent(ev); });
+        callback(events);
       }, function(errorMessage) {
-        console.log("Localhackday API could not show events because: " + errorMessage);
+        console.error("Localhackday API could not show events because: " + errorMessage);
       });
+
+      return true;
     },
     // END View all events from the API
+
+
+
+
+    // START Register new hackathon
+    /**
+     * Example code:
+     * Localhackday.registerNewHackerForEvent("Jon", "Gottfried", "Nyack, NY", "jon@mlh.io", "01234567890", function(){
+     *   console.log("New event has been registered! You should receive an email with your password & details.");
+     * }, function(errorMessage){
+     *   console.error(errorMessage);
+     * })
+     */
+    registerNewEvent: function(first_name, last_name, city, school, email, mobile, callbackSuccess, callbackError) {
+      this.queryAPI("POST", "/events/new.json", {
+        first_name: first_name,
+        last_name: last_name,
+        city: city,
+        school: school,
+        email: email,
+        mobile: (typeof mobile !== "undefined") ? mobile : ""
+      }, callbackSuccess, callbackError);
+
+      return true;
+    },
+    // END Register new hackathon
+
+
+
+
+    // START Register hacker for existing Localhackday
+    /**
+     * Example code:
+     * Localhackday.registerNewHackerForEvent("los-angeles-ca", "Shy", "Ruparel", "shy@mlh.io", "University of Cincinatti", "2015", "Computer Science", function(){
+     *   console.log("Shy Ruparel has been registered for the los-angeles-ca event!");
+     * }, function(errorMessage){
+     *   console.error(errorMessage);
+     * })
+     */
+    registerNewHackerForEvent: function(hackathon, first_name, last_name, email, school, year, major, callbackSuccess, callbackError) {
+      if(typeof hackathon === "object") {
+        hackathon = hackathon.id;
+      }
+
+      this.queryAPI("POST", "/events/" + (hackathon) + "/hackers/new.json", {
+        first_name: first_name,
+        last_name: last_name,
+        email: email,
+        school: school,
+        year: year,
+        major: major
+      }, callbackSuccess, callbackError);
+
+      return true;
+    },
+    // END Register hacker for existing Localhackday
+
+
 
 
     // START General AJAX function
@@ -26,11 +118,15 @@
             success(json);
           } else if(typeof error === "function") {
             error(json.message);
+          } else {
+            console.error(json.message);
           }
         },
         error: function(jqXHR, textStatus, errorThrown) {
           if(typeof error === "function") {
             error(textStatus);
+          } else {
+            console.error(textStatus);
           }
         }
 
@@ -40,5 +136,12 @@
 
   };
 
+
+
+
+  /**
+   * Assign as a global variable so we can use it outside of this script.
+   */
+  window.Localhackday = Localhackday;
 
 })(jQuery);

--- a/js/localhackday.js
+++ b/js/localhackday.js
@@ -5,7 +5,6 @@
    */
   var LocalhackdayEvent;
   LocalhackdayEvent = function(data) { this.raw = data; };
-  LocalhackdayEvent.prototype = Object;
   LocalhackdayEvent.prototype.id = function() { return this.raw.id; }
   LocalhackdayEvent.prototype.city = function() { return this.raw.city; }
   LocalhackdayEvent.prototype.location = function() { return this.raw.geo.address; }
@@ -24,7 +23,7 @@
    */
 
   var Localhackday = {
-    base_url: "http://organizer.mlh.io.dev/localhackday/api", // Base API URL
+    base_url: "http://organizer.mlh.io/localhackday/api", // Base API URL
 
     // START View all events from the API
     /**

--- a/js/localhackday.js
+++ b/js/localhackday.js
@@ -15,7 +15,6 @@
   LocalhackdayEvent.prototype.organizerOrganization = function() { return this.raw.organizers.organization; }
   LocalhackdayEvent.prototype.organizerUrl = function() { return this.raw.organizers.url; }
   LocalhackdayEvent.prototype.toString = function() { return this.raw; };
-
   LocalhackdayEvent.prototype.registerHacker = function(first_name, last_name, email, school, year, major, callbackSuccess, callbackError) {
     Localhackday.registerNewHackerForEvent(this.id(), first_name, last_name, email, school, year, major, callbackSuccess, callbackError);
   };

--- a/js/localhackday.js
+++ b/js/localhackday.js
@@ -1,0 +1,44 @@
+(function($){
+
+  var Localhackday = {
+    base_url: "http://organizer.mlh.io.dev/localhackday/api", // Base API URL
+
+    // START View all events from the API
+    getAll: function(callback) {
+      this.queryAPI("GET", "/events.json", null, function(response) {
+        console.log(response);
+      }, function(errorMessage) {
+        console.log("Localhackday API could not show events because: " + errorMessage);
+      });
+    },
+    // END View all events from the API
+
+
+    // START General AJAX function
+    queryAPI: function(method, resource, parameters, success, error) {
+      return $.ajax({
+        url: this.base_url + resource
+        method: method,
+        data: parameters || {},
+        dataType: "json",
+        success: function(json, textStatus, jqXHR) {
+          if(typeof success === "function" && json.status === "OK") {
+            success(json);
+          } else if(typeof error === "function") {
+            error(json.message);
+          }
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+          if(typeof error === "function") {
+            error(textStatus);
+          }
+        }
+
+      });
+    }
+    // END General AJAX function
+
+  };
+
+
+})(jQuery);

--- a/js/localhackday.js
+++ b/js/localhackday.js
@@ -17,7 +17,7 @@
     // START General AJAX function
     queryAPI: function(method, resource, parameters, success, error) {
       return $.ajax({
-        url: this.base_url + resource
+        url: this.base_url + resource,
         method: method,
         data: parameters || {},
         dataType: "json",


### PR DESCRIPTION
With the API that we're using for people to see all events, register their city and register for a Localhackday in their city I have created a lightweight JavaScript wrapper.

Should be pretty easy to understand from the `js/localhackday.js` file.

Once you're done, I don't mind hooking the wrapper up to the webpage.
